### PR TITLE
typo? fixed

### DIFF
--- a/025-array-iterator.md
+++ b/025-array-iterator.md
@@ -843,7 +843,7 @@ struct array_iterator
 
     bool operator < ( array_iterator const & right ) const
     {
-        return i < right ;
+        return i < right.i ;
     }
 }
 ~~~


### PR DESCRIPTION
Dear Mr.Ezoe,
Hello.This is renkarsu.

I found a typo.
L846
type of variable "i" is size_t, but type of "right" is array_iterator const &.

追伸
　癖で英語にしたのですが、日本語の方が都合よろしいでしょうか。
　加えて、pull requestとissueどちらの方がよいでしょうか。
　他にもいくつかtypoを見つけました。しかし、どこだったかは覚えていないので、時間がある時に送ろうと思います。